### PR TITLE
Abort if no 'run_tests' label

### DIFF
--- a/checks/check-meta.py
+++ b/checks/check-meta.py
@@ -90,6 +90,15 @@ def check_labels():
     return True
 
 
+def check_run_tests():
+    if 'run_tests' in gh_labels:
+        print('run_tests:ok')
+        return True
+    else:
+        print(r'run_tests:ko')
+        return False
+
+
 def check_title():
     if 'bypass title check' in gh_labels:
         print('title:bypass')
@@ -226,6 +235,11 @@ def main():
             sys.exit(0)
         else:
             sys.exit(1)
+
+    if not check_run_tests():
+        print('meta:abort')
+        sys.exit(1)
+
     ok = True
     ok = check_labels() and ok
     ok = check_title() and ok


### PR DESCRIPTION
Idéalement ce test devrait être le premier à être fait, dans before-check mais cela nécessite trop de refactoring pour le faire proprement.

Je pourrai le faire vendredi prochain (15/05) si c'est la solution retenue mais je ne pense pas que ce soit la bonne : 

* Pour que ça fonctionne il faut ajouter "Ajout / Suppression d'étiquettes" à la liste des événements déclenchant le hook
* **Inconvénients** => Chaque modification de la liste des labels déclenchera le lancement d'une instance drone.